### PR TITLE
ENG-7980 Add implementation for socket.sendall

### DIFF
--- a/Lib/_socket.py
+++ b/Lib/_socket.py
@@ -1217,8 +1217,13 @@ class _realsocket(object):
         log.debug("Sent data <<<{!r:.20}>>>".format(sent_data), extra={"sock": self})
 
         return len(sent_data)
-
-    sendall = send   # FIXME see note above!
+    
+    def sendall(self, data, flags=0):
+        chunk_size = 8192
+        total_sent = 0
+        while total_sent < len(data):
+            sent = self.send(data[total_sent:total_sent + chunk_size], flags=flags)
+            total_sent += sent
 
     def _get_incoming_msg(self, reason):
         log.debug("head=%s incoming=%s" % (self.incoming_head, self.incoming), extra={"sock": self})


### PR DESCRIPTION
This PR closes below issues:

[Issue 2618](https://bugs.jython.org/issue2618) - socket.sendall no longer sends all
[Issue 2894](https://bugs.jython.org/issue2894) -  urllib2 POST > 64k fails

Both issues require to implement socket.sendall method.

**Important**

PR https://github.com/jython/jython/pull/80 from jython provides implementation of socket.sendall. However it does not work as expected due to `memoryview`.

```
TypeError: cannot make memory view because object does not have the buffer interface
	at org.python.core.Py.TypeError(Py.java:236)
	at org.python.core.PyMemoryView.memoryview_new(PyMemoryView.java:77)
	at org.python.core.PyMemoryView$exposed___new__.new_impl(Unknown Source)
	at org.python.core.PyType.invokeNew(PyType.java:1119)
	at org.python.core.PyType.type___call__(PyType.java:2399)
	at org.p
```
